### PR TITLE
Data charset format fix for IE

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function(opts) {
 					width: res.info.width,
 					height: res.info.height,
 					data: [
-						'url(data:image/svg+xml;utf8,',
+						'url(data:image/svg+xml;charset=utf8,',
 						encodeURIComponent(res.data),
 						')'
 					].join(''),


### PR DESCRIPTION
Adding charset= before utf8 makes the SVG data URIs work in Internet Explorer