### PR TITLE
Replaced deprecated module gulp-util with vinyl

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var path = require('path');
 var sizeOf = require('image-size');
 var mustache = require('mustache');
 var through = require('through');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var mime = require('mime');
 var SVGO = require('svgo');
 var svgo = new SVGO();
@@ -55,7 +55,7 @@ module.exports = function(opts) {
 	};
 
 	var endStream = function() {
-		this.emit('data', new gutil.File({
+		this.emit('data', new Vinyl({
 			  contents: new Buffer(mustache.render(tpl, {
 				  items: buffer
 			  }), 'utf8'),

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "main": "index.js",
   "dependencies": {
-    "gulp-util": "~2.2.14",
     "image-size": "^0.4.0",
     "imagesize": "~1.0.0",
     "mime": "~1.2.11",
     "mustache": "~0.8.1",
     "svgo": "^0.5.0",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "mocha": "~1.18.2",

--- a/test/main.js
+++ b/test/main.js
@@ -1,12 +1,12 @@
 var baseimg = require('../');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var should = require('should');
 var fs = require('fs');
 var postcss = require('postcss');
 require('mocha');
 
 var loadFile = function(path) {
-	return new gutil.File({
+	return new Vinyl({
 		path: path,
 		contents: fs.readFileSync(path)
 	});


### PR DESCRIPTION
gulp-utils has [been deprecated](https://github.com/gulpjs/gulp-util)
And it breaks [gulp version 4](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5).
gulp-utils module has been replaced with Vinyl.